### PR TITLE
CI: add test workflow with GitHub actions

### DIFF
--- a/.github/workflow/pr_test.yaml
+++ b/.github/workflow/pr_test.yaml
@@ -1,0 +1,61 @@
+name: pr_test
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  pr_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v3
+        id: get-pr
+        with:
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      - name: Check out pull request head
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+          ref: ${{ fromJSON(steps.get-pr.outputs.result).head.sha }}
+
+      - name: Setup node 14 env
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Build the website
+        run: |
+          npm install
+          npm run build
+
+      - name: Upload to OSS
+        uses: tvrcgo/upload-to-oss@master
+        with:
+          key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          region: ${{ secrets.OSS_REGION }}
+          bucket: ${{ secrets.OSS_BUCKET }}
+          assets: |
+            ./build/**:${{ secrets.OSS_TARGET_PATH }}${{ github.event.issue.number }}/
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: The website for this PR is deployed at https://oss.x-lab.info/${{ secrets.OSS_TARGET_PATH }}${{ github.event.issue.number }}/


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Add a test workflow for PRs in the repo, the workflow steps are:

- Use latest Ubuntu system
- Get the PR head from the event
- Checkout the PR head into the environment
- Setup Node.js v14
- Build the website
- Upload build files on to OSS
- Comment result back to the PR

close #4 