### PR TITLE
[Fix] Change pr test to comment trigger

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,16 +1,25 @@
 name: pr_test
 
 on:
-  pull_request:
-    types: [ opened, synchronize, reopened ]
+  issue_comment:
+    types: [created]
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  pr_test:
+  pr-test:
+    if: github.event.issue.pull_request
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Check comment command
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '^/build-test$'
+
       - uses: actions/github-script@v3
         id: get-pr
         with:


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

We should change the trigger type to `issue_comment` because PR's CI is running on forked repo and can not access any secrets in the action workflows.