### PR TITLE
[CI/CD] Add hackathon branch build in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, nebula-hackathon ]
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

During Hackathon, we need to add hackathon branch build into CI/CD because this branch is the default branch right now.